### PR TITLE
C\C++ native module sopport

### DIFF
--- a/components/jerry-module/jerry-module.c
+++ b/components/jerry-module/jerry-module.c
@@ -6,6 +6,8 @@
 #include "jerryscript-ext/handler.h"
 #include "jerryscript-port.h"
 
+extern jerry_value_t nodemcujs_module_get(const char* name);
+
 static jerry_value_t require_handler(const jerry_value_t func_value, /**< function object */
                                      const jerry_value_t this_value, /**< this arg */
                                      const jerry_value_t args[],     /**< function arguments */
@@ -15,6 +17,12 @@ static jerry_value_t require_handler(const jerry_value_t func_value, /**< functi
   jerry_char_t name[strLen + 1];
   jerry_string_to_char_buffer(args[0], name, strLen);
   name[strLen] = '\0';
+
+  jerry_value_t native = nodemcujs_module_get((char *)name);
+  if (native != NULL)
+  {
+    return native;
+  }
 
   size_t size = 0;
   jerry_char_t *script = jerry_port_read_source((char *)name, &size);

--- a/components/nodemcujs_buildin/CMakeLists.txt
+++ b/components/nodemcujs_buildin/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required (VERSION 2.8.12)
+
+set(COMPONENT_ADD_INCLUDEDIRS include)
+set(COMPONENT_SRCDIRS .)
+
+set(COMPONENT_PRIV_INCLUDEDIRS
+    ${JERRYSCRIPT_SOURCE}/jerry-core/include
+    ${JERRYSCRIPT_SOURCE}/jerry-ext/include
+    ${JERRYSCRIPT_SOURCE}/jerry-port/default/include)
+
+register_component()

--- a/components/nodemcujs_buildin/component.mk
+++ b/components/nodemcujs_buildin/component.mk
@@ -1,0 +1,5 @@
+#
+# "main" pseudo-component makefile.
+#
+# (Uses default behaviour of compiling all source files in directory, adding 'include' to include path.)
+

--- a/components/nodemcujs_buildin/include/nodemcujs_module_inl.h
+++ b/components/nodemcujs_buildin/include/nodemcujs_module_inl.h
@@ -1,0 +1,33 @@
+#ifndef MODULE_BUILDIN_H
+#define MODULE_BUILDIN_H
+
+#include "jerryscript.h"
+
+// buildin modules
+extern jerry_value_t nodemcujs_init_gpio();
+
+
+typedef jerry_value_t (*register_func)();
+
+typedef struct
+{
+  const char* name;
+  register_func fn_register;
+} nodemcujs_module_t;
+
+typedef struct
+{
+  jerry_value_t jmodule;
+} nodemcujs_module_objects_t;
+
+const nodemcujs_module_t nodemcujs_modules[] = {
+  { "gpio", nodemcujs_init_gpio }
+};
+
+const unsigned nodemcujs_modules_count = sizeof(nodemcujs_modules) / sizeof(nodemcujs_module_t);
+
+nodemcujs_module_objects_t nodemcujs_module_objects[sizeof(nodemcujs_modules) / sizeof(nodemcujs_module_t)];
+
+jerry_value_t nodemcujs_module_get(const char* name);
+
+#endif

--- a/components/nodemcujs_buildin/nodemcujs_buildin.c
+++ b/components/nodemcujs_buildin/nodemcujs_buildin.c
@@ -1,0 +1,20 @@
+#include "include/nodemcujs_module_inl.h"
+
+#include <string.h>
+
+jerry_value_t nodemcujs_module_get(const char* name)
+{
+  for (unsigned i = 0; i < nodemcujs_modules_count; i++)
+  {
+    if (!strcmp(name, nodemcujs_modules[i].name))
+    {
+      if (nodemcujs_module_objects[i].jmodule == 0)
+      {
+        nodemcujs_module_objects[i].jmodule = nodemcujs_modules[i].fn_register();
+      }
+      return nodemcujs_module_objects[i].jmodule;
+    }
+  }
+  // buildin module not found.
+  return NULL;
+}

--- a/components/nodemcujs_module_gpio/CMakeLists.txt
+++ b/components/nodemcujs_module_gpio/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required (VERSION 2.8.12)
+
+set(COMPONENT_ADD_INCLUDEDIRS include)
+set(COMPONENT_SRCDIRS .)
+
+set(COMPONENT_PRIV_INCLUDEDIRS
+    ${JERRYSCRIPT_SOURCE}/jerry-core/include
+    ${JERRYSCRIPT_SOURCE}/jerry-ext/include
+    ${JERRYSCRIPT_SOURCE}/jerry-port/default/include)
+
+register_component()

--- a/components/nodemcujs_module_gpio/component.mk
+++ b/components/nodemcujs_module_gpio/component.mk
@@ -1,0 +1,5 @@
+#
+# "main" pseudo-component makefile.
+#
+# (Uses default behaviour of compiling all source files in directory, adding 'include' to include path.)
+

--- a/components/nodemcujs_module_gpio/include/nodemcujs_module_gpio.h
+++ b/components/nodemcujs_module_gpio/include/nodemcujs_module_gpio.h
@@ -1,0 +1,6 @@
+#ifndef NODEMCUJS_MODULE_GPIO
+#define NODEMCUJS_MODULE_GPIO
+
+#include "jerryscript.h"
+
+#endif

--- a/components/nodemcujs_module_gpio/nodemcujs_module_gpio.c
+++ b/components/nodemcujs_module_gpio/nodemcujs_module_gpio.c
@@ -1,0 +1,71 @@
+#include "include/nodemcujs_module_gpio.h"
+
+#include "esp_err.h"
+
+#include "driver/gpio.h"
+
+static jerry_value_t mode_handler(const jerry_value_t func_value, /**< function object */
+                                  const jerry_value_t this_value, /**< this arg */
+                                  const jerry_value_t args[],     /**< function arguments */
+                                  const jerry_length_t args_cnt)  /**< number of function arguments */
+{
+  int pin_num = (int)jerry_get_number_value(args[0]);
+  int pin_mode = (int)jerry_get_number_value(args[1]);
+  esp_err_t status = gpio_set_direction(pin_num, pin_mode);
+  if (status != ESP_OK)
+  {
+    printf("gpio_set_direction error!\n");
+    return jerry_create_boolean(false);
+  }
+  return jerry_create_boolean(true);
+}
+
+static jerry_value_t write_handler(const jerry_value_t func_value, /**< function object */
+                                   const jerry_value_t this_value, /**< this arg */
+                                   const jerry_value_t args[],     /**< function arguments */
+                                   const jerry_length_t args_cnt)  /**< number of function arguments */
+{
+  int pin_num = (int)jerry_get_number_value(args[0]);
+  uint32_t pin_level = (uint32_t)jerry_get_number_value(args[1]);
+  esp_err_t status = gpio_set_level(pin_num, pin_level);
+  if (status != ESP_OK)
+  {
+    printf("gpio_set_level error!\n");
+    return jerry_create_boolean(false);
+  }
+  return jerry_create_boolean(true);
+}
+
+static jerry_value_t read_handler(const jerry_value_t func_value, /**< function object */
+                                  const jerry_value_t this_value, /**< this arg */
+                                  const jerry_value_t args[],     /**< function arguments */
+                                  const jerry_length_t args_cnt)  /**< number of function arguments */
+{
+  int pin_num = (int)jerry_get_number_value(args[0]);
+  int level = gpio_get_level(pin_num);
+  return jerry_create_number((double)level);
+}
+
+jerry_value_t nodemcujs_init_gpio()
+{
+  jerry_value_t gpio = jerry_create_object();
+  jerry_value_t prop_name = jerry_create_string((const jerry_char_t *)"mode");
+  jerry_value_t value = jerry_create_external_function(mode_handler);
+  jerry_release_value(jerry_set_property(gpio, prop_name, value));
+  jerry_release_value(prop_name);
+  jerry_release_value(value);
+
+  prop_name = jerry_create_string((const jerry_char_t *)"write");
+  value = jerry_create_external_function(write_handler);
+  jerry_release_value(jerry_set_property(gpio, prop_name, value));
+  jerry_release_value(prop_name);
+  jerry_release_value(value);
+
+  prop_name = jerry_create_string((const jerry_char_t *)"read");
+  value = jerry_create_external_function(read_handler);
+  jerry_release_value(jerry_set_property(gpio, prop_name, value));
+  jerry_release_value(prop_name);
+  jerry_release_value(value);
+
+  return gpio;
+}


### PR DESCRIPTION
```c
// components/nodemcujs_module_gpio/nodemcujs_module_gpio.c

jerry_value_t nodemcujs_init_gpio()
{
    jerry_value_t gpio = jerry_create_object();

    // ......
    return gpio;
}
```

然后再注册该模块：

```c
// components/nodemcujs_buildin/include/nodemcujs_module_inl.h

extern jerry_value_t nodemcujs_init_gpio();
const nodemcujs_module_t nodemcujs_modules[] = {
  { "gpio", nodemcujs_init_gpio }
};
```

只需要 2 步我们就完成了 native 模块的注册，最后可以在 JS 中使用它了：

```js
var gpio = require('gpio')
```